### PR TITLE
📝 Add back missing step

### DIFF
--- a/hello/ssh-github.md
+++ b/hello/ssh-github.md
@@ -8,23 +8,23 @@
     - If you choose to make your email private in step (5) above, then your commit email will be the `...@users.noreply.github.com`
 4) Save your commit email in a `.txt` file for later
 ---
-4) Generate a SSH key and add it to your ssh-agent following these [instructions](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent)
+5) Generate a SSH key and add it to your ssh-agent following these [instructions](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent)
     - Windows users should follow the linux instructions in their WSL terminal
     - Everyone can skip the "Generating a new SSH key for a hardware security key" section
----
-5) Add the SSH keys to your GitHub account following these [instructions](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account)
+6) Add the SSH keys to your GitHub account following these [instructions](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account)
     - Windows users should follow the linux instructions in their WSL terminal
-6) Take a screenshot after you finish adding the keys
-7) Edit the screenshot to censor the key entries
+7) Take a screenshot after you finish adding the keys
+8) Edit the screenshot to censor the key entries
 ---
-6) Open your terminal
-7) Run `git config --global user.name "Your Name"` where "Your Name" is your GitHub username
-8) Run `git config --global user.email commit@email.com` where "commit@email.com" is your commit email from step (2) of these instructions.
+9) Open your terminal
+10) Run `git config --global user.name "Your Name"` where "Your Name" is your GitHub username
+11) Run `git config --global user.email commit@email.com` where "commit@email.com" is your commit email from step (2) of these instructions.
     - Do not put quotes around your email in the above command!
-9) Run `git config --edit --global` to view your global `.gitconfig` file in vim in your terminal
-10) Take a screenshot showing the username and email you added
+12) Run `git config --global core.sshCommand = ssh -i ~/.ssh/path-to-your-private-key` where `path-to-your-private-key` may look something like `~/.ssh/id_ed25519` if you accepted the default file name in step (5).
+13) Run `git config --edit --global` to view your global `.gitconfig` file in vim in your terminal
+14) Take a screenshot showing the username and email you added
     - If you are a Windows user using WSL, then you need to click outside the terminal to take a screenshot
-11) Exit vim by entering `:q`
+15) Exit vim by entering `:q`
 
 ## 🌸 FAQ
 


### PR DESCRIPTION
jk; If we deleted this step we would have to run `eval "$(ssh-agent -s)"; ssh-add ~/.ssh/path-to-your-private-key` each time we restart the (WSL) terminal. Directly putting those lines into your `.bashrc` does not work as expected either, so Linh Nguyen My's solution in the references for Windows machines is actually useful in general if you use unix systems like WSL too.